### PR TITLE
Add the installation of unzip if not already installed

### DIFF
--- a/readsb-install.sh
+++ b/readsb-install.sh
@@ -30,7 +30,7 @@ udevadm control --reload-rules
 apt-get update
 apt-get install --no-install-recommends --no-install-suggests -y git build-essential debhelper libusb-1.0-0-dev \
     librtlsdr-dev librtlsdr0 pkg-config dh-systemd \
-    libncurses5-dev lighttpd zlib1g-dev zlib1g
+    libncurses5-dev lighttpd zlib1g-dev zlib1g unzip
 
 rm -rf "$ipath"/git
 if ! git clone --branch stale --depth 1 "$repository" "$ipath/git"


### PR DESCRIPTION
Unzip added the packages to install with apt-get for distributions where it is not already installed. This fixes the problem of web files not being installed on the Orange Pi Debian distribution. It will have no affect on systems where it is already installed.