### PR TITLE
readsb-gain script

### DIFF
--- a/readsb-install.sh
+++ b/readsb-install.sh
@@ -146,7 +146,7 @@ cat >/usr/local/bin/readsb-gain <<"EOF"
 validre='^(-10|[0-9]+([.][0-9]+)?)$'
 gain=$(echo $1 | tr -cd '[:digit:].-')
 if ! [[ $gain =~ $validre ]] ; then echo "Error, invalid gain!"; exit 1; fi
-if ! grep gain /etc/default/readsb &>/dev/null; then sed -i -e 's/RECEIVER_OPTIONS="/RECEIVER_OPTIONS="--gain 49.6 /' /etc/default/readsb; fi
+if ! grep gain /etc/default/readsb &>/dev/null; then sudo sed -i -e 's/RECEIVER_OPTIONS="/RECEIVER_OPTIONS="--gain 49.6 /' /etc/default/readsb; fi
 sudo sed -i -E -e "s/--gain .?[0-9]*.?[0-9]* /--gain $gain /" /etc/default/readsb
 sudo systemctl restart readsb
 EOF

--- a/readsb-install.sh
+++ b/readsb-install.sh
@@ -143,8 +143,9 @@ systemctl restart readsb || true
 mkdir -p /usr/local/bin
 cat >/usr/local/bin/readsb-gain <<"EOF"
 #!/bin/bash
+validre='^(-10|[0-9]+([.][0-9]+)?)$'
 gain=$(echo $1 | tr -cd '[:digit:].-')
-if [[ $gain == "" ]]; then echo "Error, invalid gain!"; exit 1; fi
+if ! [[ $gain =~ $validre ]] ; then echo "Error, invalid gain!"; exit 1; fi
 if ! grep gain /etc/default/readsb &>/dev/null; then sed -i -e 's/RECEIVER_OPTIONS="/RECEIVER_OPTIONS="--gain 49.6 /' /etc/default/readsb; fi
 sudo sed -i -E -e "s/--gain .?[0-9]*.?[0-9]* /--gain $gain /" /etc/default/readsb
 sudo systemctl restart readsb


### PR DESCRIPTION
This PR addresses two issues in the readsb-gain script:
1) A non-numeric arg is not always handled correctly, resulting in an invalid gain value being written to /etc/default/readsb
2) Attempting to set an initial gain value fails with a permission denied error for non-root users

**Examples:**
1.
```
$ readsb-gain --help && grep gain /etc/default/readsb
RECEIVER_OPTIONS="--device 0 --device-type rtlsdr --gain -- --ppm 0"

$ readsb-gain -h && grep gain /etc/default/readsb
RECEIVER_OPTIONS="--device 0 --device-type rtlsdr --gain - --ppm 0"

$ readsb-gain 1-2 && grep gain /etc/default/readsb
RECEIVER_OPTIONS="--device 0 --device-type rtlsdr --gain 1-2 --ppm 0"

$ readsb-gain .. && grep gain /etc/default/readsb
RECEIVER_OPTIONS="--device 0 --device-type rtlsdr --gain .. --ppm 0"
```
2. 
```
$ grep RECEIVER_OPTIONS /etc/default/readsb
RECEIVER_OPTIONS="--device 0 --device-type rtlsdr --ppm 0"

$ readsb-gain 10
sed: couldn't open temporary file /etc/default/sed4HdeAg: Permission denied

```

My proposed fix for 1. validates the sanitized input against a regex to ensure it only contains either a positive number, or -10 (AGC).
(if there's a requirement to accept negative gain values besides -10, let me know and I'll update the regex and resubmit)
2. is just a missing sudo prefix for the sed command.

**Test cases:**
1.
```
$ readsb-gain --help && grep gain /etc/default/readsb
Error, invalid gain!

$ readsb-gain -h && grep gain /etc/default/readsb
Error, invalid gain!

$ readsb-gain .. && grep gain /etc/default/readsb
Error, invalid gain!

$ readsb-gain 1-2 && grep gain /etc/default/readsb
Error, invalid gain!

$ readsb-gain +1.2 && grep gain /etc/default/readsb
RECEIVER_OPTIONS="--device 0 --device-type rtlsdr --gain 1.2 --ppm 0"

$ readsb-gain -1.2 && grep gain /etc/default/readsb
Error, invalid gain!

$ readsb-gain 1.2.3 && grep gain /etc/default/readsb
Error, invalid gain!

$ readsb-gain 0.12 && grep gain /etc/default/readsb
RECEIVER_OPTIONS="--device 0 --device-type rtlsdr --gain 0.12 --ppm 0"

$ readsb-gain -0.12 && grep gain /etc/default/readsb
Error, invalid gain!

$ readsb-gain -10 && grep gain /etc/default/readsb
RECEIVER_OPTIONS="--device 0 --device-type rtlsdr --gain -10 --ppm 0"

$ readsb-gain 40 && grep gain /etc/default/readsb
RECEIVER_OPTIONS="--device 0 --device-type rtlsdr --gain 40 --ppm 0"
```

2)
```
$ grep RECEIVER_OPTIONS /etc/default/readsb
RECEIVER_OPTIONS="--device 0 --device-type rtlsdr --ppm 0"

$ readsb-gain 10
$ grep RECEIVER_OPTIONS /etc/default/readsb
RECEIVER_OPTIONS="--gain 10 --device 0 --device-type rtlsdr --ppm 0"
```

