### PR TITLE
Update pingfail.sh

### DIFF
--- a/pingfail.sh
+++ b/pingfail.sh
@@ -3,8 +3,8 @@
 trap "exit" INT TERM
 trap "kill 0" EXIT
 
-TEST1="google.com"
-TEST2="akamai.com"
+TEST1="8.8.8.8"
+TEST2="1.1.1.1"
 FAIL="no"
 
 while sleep 300


### PR DESCRIPTION
Replacing FQDNs with IP addresses of high availability DNS servers. 

Two reasons: 
1. A DNS resolution issue could cause a system reboot unneccessarily. While that is a very remote possibility given the domains used, better safe than sorry. 
2. Faster ping response times. I consistently see faster response times from 1.1.1.1 (CloudFlare DNS) than from akamai.com. 8.8.8.8 is Google DNS and gets similiar response times to google.com.