### PR TITLE
Fix error when use cp  (GNU coreutils) 9.4

### DIFF
--- a/readsb-install.sh
+++ b/readsb-install.sh
@@ -121,7 +121,7 @@ rm -f /usr/bin/readsb /usr/bin/viewadsb
 cp -f readsb /usr/bin/readsb
 cp -f viewadsb /usr/bin/viewadsb
 
-cp -n debian/readsb.default /etc/default/readsb
+cp --update=none debian/readsb.default /etc/default/readsb
 
 if ! id -u readsb &>/dev/null
 then
@@ -140,7 +140,7 @@ rm -f /etc/lighttpd/conf-enabled/89-dump1090.conf
 
 if [[ -f /etc/rbfeeder.ini ]]; then
     systemctl stop rb-feeder &>/dev/null || true
-    cp -n /etc/rbfeeder.ini /usr/local/share/adsb-wiki || true
+    cp --update=none /etc/rbfeeder.ini /usr/local/share/adsb-wiki || true
     sed -i -e '/network_mode/d' -e '/\[network\]/d' -e '/mode=/d' -e '/external_port/d' -e '/external_host/d' /etc/rbfeeder.ini
     sed -i -e 's/\[client\]/\0\nnetwork_mode=true/' /etc/rbfeeder.ini
     cat >>/etc/rbfeeder.ini <<"EOF"
@@ -160,7 +160,7 @@ then
     systemctl stop fr24feed &>/dev/null || true
     chmod a+rw /etc/fr24feed.ini || true
     apt-get install -y dos2unix &>/dev/null && dos2unix /etc/fr24feed.ini &>/dev/null || true
-    cp -n /etc/fr24feed.ini /usr/local/share/adsb-wiki || true
+    cp --update=none /etc/fr24feed.ini /usr/local/share/adsb-wiki || true
 
     if ! grep -e 'host=' /etc/fr24feed.ini &>/dev/null; then echo 'host=' >> /etc/fr24feed.ini; fi
     if ! grep -e 'receiver=' /etc/fr24feed.ini &>/dev/null; then echo 'receiver=' >> /etc/fr24feed.ini; fi


### PR DESCRIPTION
Update script for cp (GNU coreutils) 9.4
When use this script an error:
cp: not replacing '/etc/default/readsb'
[ERROR] Error in line 124 when executing: cp -n debian/readsb.default /etc/default/readsb
due to:
cp options -n changed see:
https://github.com/coreutils/coreutils/blob/c2173c0a52925245d4fe27890f9ced1b5d860372/NEWS#L89-L91
https://github.com/coreutils/coreutils/blob/c2173c0a52925245d4fe27890f9ced1b5d860372/NEWS#L179-L182
