### PR TITLE
autogain1090 handle config comment lines cleanly

### DIFF
--- a/autogain-install.sh
+++ b/autogain-install.sh
@@ -112,9 +112,9 @@ strong=$percent
 if [[ $strong == "nan" ]]; then echo "Error, can't automatically adjust gain!"; exit 1; fi
 
 if [ -f /boot/adsb-config.txt ]; then
-    oldgain=$(grep -P -e 'GAIN=\K[0-9-.]*' -o /boot/adsb-config.txt)
+    oldgain=$(grep -P -e '^(?=[\s]*+[^#])[^#]*GAIN=\K[0-9-.]*' -o /boot/adsb-config.txt)
 else
-    oldgain=$(grep -P -e 'gain \K[0-9-.]*' -o /etc/default/$APP)
+    oldgain=$(grep -P -e '^(?=[\s]*+[^#])[^#]*gain \K[0-9-.]*' -o /etc/default/$APP)
 fi
 
 if [[ "$oldgain" == "" ]]; then
@@ -178,7 +178,7 @@ else
     if ! grep gain /etc/default/$APP &>/dev/null && grep -E 'device-type.*rtlsdr' /etc/default/$APP &>/dev/null; then
       sed --follow-symlinks -i -e 's/RECEIVER_OPTIONS="/RECEIVER_OPTIONS="--gain 49.6 /' /etc/default/$APP
     fi
-    sed --follow-symlinks -i -E -e "s/--gain -?[0-9]*\.?[0-9]*/--gain $gain/" /etc/default/$APP
+    sed --follow-symlinks -i -E -e "/^[[:space:]]*#/b; /--gain/ s/--gain -?[0-9]*\.?[0-9]*/--gain $gain/" /etc/default/$APP
 fi
 
 systemctl restart $APP

--- a/readsb-install.sh
+++ b/readsb-install.sh
@@ -243,7 +243,7 @@ validre='^([^ ]*)$'
 gain="$1"
 if ! [[ $gain =~ $validre ]] ; then echo "Error, invalid gain!"; exit 1; fi
 if ! grep gain /etc/default/readsb &>/dev/null; then sudo sed -i -e 's/RECEIVER_OPTIONS="/RECEIVER_OPTIONS="--gain 49.6 /' /etc/default/readsb; fi
-sudo sed -i -E -e "s/--gain[ =][^ \"]*/--gain $gain/" /etc/default/readsb
+sudo sed -i -E -e "/^[[:space:]]*#/b; /--gain/ s/--gain[ =][^ \"]*/--gain $gain/" /etc/default/readsb
 echo "$gain" | sudo tee /run/readsb/setGain || sudo systemctl restart readsb
 EOF
 chmod a+x /usr/local/bin/readsb-gain


### PR DESCRIPTION
PR to address issue #48 

Test with `/etc/default/readsb` containing:
```
# RECEIVER_OPTIONS="--device 0 --device-type rtlsdr --gain 48.0 --ppm 50"
RECEIVER_OPTIONS="--device 0 --device-type rtlsdr --gain -10 --ppm 25"
```

`autogain1090` now correctly sets `oldgain`, correctly determines the new gain setting, and does not modify commented lines: 
```
++ grep -P -e '^(?=[\s]*+[^#])[^#]*gain \K[0-9-.]*' -o /etc/default/readsb
+ oldgain=-10
+ [[ -10 == '' ]]
+ gain_index=28
+ for i in "${!ga[@]}"
+ awk 'BEGIN{ exit  (-10 <= 0.0) }'
+ gain_index=0
+ break
+ awk 'BEGIN{ exit  (-10 > 49.6) }'
+ [[ -10 == \-\1\0 ]]
+ gain_index=29
+ awk 'BEGIN{ exit (7.117 > 0.5) }'
+ awk 'BEGIN{ exit (7.117 < 7.0) }'
+ awk 'BEGIN{ exit (7.117 < 0.5) }'
+ awk 'BEGIN{ exit (7.117 < 0.5) }'
+ awk 'BEGIN{ exit (7.117 > 7.0) }'
+ [[ 29 == 0 ]]
+ awk 'BEGIN{ exit (7.117 > 7.0) }'
+ gain_index=28
+ action=Decreasing
+ gain=49.6
+ [[ 49.6 == '' ]]
+ '[' -f /boot/piaware-config.txt ']'
+ '[' -f /boot/adsb-config.txt ']'
+ grep gain /etc/default/readsb
+ sed --follow-symlinks -i -E -e '/^[[:space:]]*#/b; /--gain/ s/--gain -?[0-9]*\.?[0-9]*/--gain 49.6/' /etc/default/readsb
+ systemctl restart readsb
+ echo 0
+ echo 0
+ echo 'Decreasing gain to 49.6 (7.117% messages >-3dB)'
Decreasing gain to 49.6 (7.117% messages >-3dB)
```

Resulting `/etc/default/readsb`:
```
# RECEIVER_OPTIONS="--device 0 --device-type rtlsdr --gain 48.0 --ppm 50"
RECEIVER_OPTIONS="--device 0 --device-type rtlsdr --gain 49.6 --ppm 25"
```
